### PR TITLE
PowerShell throw statements should use subexpression syntax for object properties in expandable strings

### DIFF
--- a/centrify-samples-powershell.pssproj
+++ b/centrify-samples-powershell.pssproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>6CAFC0C6-A428-4d30-A9F9-700E829FEA51</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyApplication</RootNamespace>
+    <AssemblyName>MyApplication</AssemblyName>
+    <Name>centrify-samples-powershell</Name>
+    <Author />
+    <CompanyName>Centrify</CompanyName>
+    <Copyright />
+    <Description>This package contains code samples for the Centrify Identity Service Platform API's written in PowerShell.</Description>
+    <Guid>97c658dd-f051-40af-8b70-e2f3debe005c</Guid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="functions\" />
+    <Folder Include="module\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=".gitattributes" />
+    <Compile Include=".gitignore" />
+    <Compile Include="Centrify.Samples.PowerShell.Example.ps1" />
+    <Compile Include="Centrify.Samples.Powershell.Example.SalesforceLicenses.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.AddAccount.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.AddResource.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.DeleteAccount.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.DeleteResource.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.UpdateAccount .ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.UpdatePassword.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CPS.UpdateResource.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.CreateUser.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.GetRoleApps.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.GetUPData.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.Query.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.SetUserState.1.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.SetUserState.ps1" />
+    <Compile Include="functions\Centrify.Samples.PowerShell.UpdateApplicationDE.ps1" />
+    <Compile Include="LICENSE.md" />
+    <Compile Include="module\Centrify.Samples.PowerShell.psm1" />
+    <Compile Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="Build" />
+</Project>

--- a/centrify-samples-powershell.sln
+++ b/centrify-samples-powershell.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F5034706-568F-408A-B7B3-4D38C6DB8A32}") = "centrify-samples-powershell", "centrify-samples-powershell.pssproj", "{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/functions/Centrify.Samples.PowerShell.CPS.AddAccount.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.AddAccount.ps1
@@ -40,7 +40,7 @@ function AddAccount {
     $restResult = Centrify-InvokeREST -Method "ServerManage/AddAccount" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.AddResource.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.AddResource.ps1
@@ -41,7 +41,7 @@ function AddResource {
     $restResult = Centrify-InvokeREST -Method "/ServerManage/AddResource" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.DeleteAccount.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.DeleteAccount.ps1
@@ -29,7 +29,7 @@ function DeleteAccount {
     $restResult = Centrify-InvokeREST -Method "ServerManage/DeleteAccount" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.DeleteResource.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.DeleteResource.ps1
@@ -31,7 +31,7 @@ function DeleteResource {
     $restResult = Centrify-InvokeREST -Method "/ServerManage/DeleteResource" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.UpdateAccount .ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.UpdateAccount .ps1
@@ -40,7 +40,7 @@ function UpdateAccount {
     $restResult = Centrify-InvokeREST -Method "ServerManage/UpdateAccount" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.UpdatePassword.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.UpdatePassword.ps1
@@ -32,7 +32,7 @@ function UpdatePassword {
     $restResult = Centrify-InvokeREST -Method "ServerManage/UpdatePassword" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CPS.UpdateResource.ps1
+++ b/functions/Centrify.Samples.PowerShell.CPS.UpdateResource.ps1
@@ -61,7 +61,7 @@ function UpdateResource {
     $restResult = Centrify-InvokeREST -Method "/ServerManage/UpdateResource" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result		    

--- a/functions/Centrify.Samples.PowerShell.CreateUser.ps1
+++ b/functions/Centrify.Samples.PowerShell.CreateUser.ps1
@@ -32,7 +32,7 @@ function CreateUser {
     $restResult = Centrify-InvokeREST -Method "/cdirectoryservice/createuser" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result

--- a/functions/Centrify.Samples.PowerShell.GetRoleApps.ps1
+++ b/functions/Centrify.Samples.PowerShell.GetRoleApps.ps1
@@ -27,7 +27,7 @@ function GetRoleApps {
     $restResult = Centrify-InvokeREST -Method "/saasmanage/getroleapps?role=$role" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result.Results

--- a/functions/Centrify.Samples.PowerShell.GetUPData.ps1
+++ b/functions/Centrify.Samples.PowerShell.GetUPData.ps1
@@ -26,7 +26,7 @@ function GetUPData {
     $restResult = Centrify-InvokeREST -Method "/uprest/getupdata" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
     
     return $restResult.Result.Apps

--- a/functions/Centrify.Samples.PowerShell.Query.ps1
+++ b/functions/Centrify.Samples.PowerShell.Query.ps1
@@ -33,7 +33,7 @@ function Query {
     $queryResult = Centrify-InvokeREST -Method "/redrock/query" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($queryResult.success -ne $true)
     {
-        throw "Server error: $queryResult.Message"
+        throw "Server error: $($queryResult.Message)"
     }     
     
     return $queryResult.Result

--- a/functions/Centrify.Samples.PowerShell.SetUserState.1.ps1
+++ b/functions/Centrify.Samples.PowerShell.SetUserState.1.ps1
@@ -34,6 +34,6 @@ function UpdateApplicationDE {
     $restResult = Centrify-InvokeREST -Method "/saasmanage/updateapplicationde?_RowKey=$appKey" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
 }

--- a/functions/Centrify.Samples.PowerShell.SetUserState.ps1
+++ b/functions/Centrify.Samples.PowerShell.SetUserState.ps1
@@ -31,6 +31,6 @@ function SetUserState {
     $restResult = Centrify-InvokeREST -Method "/cdirectoryservice/setuserstate" -Endpoint $endpoint -Token $bearerToken -ObjectContent $restArg -Verbose:$enableVerbose
     if($restResult.success -ne $true)
     {
-        throw "Server error: $restResult.Message"
+        throw "Server error: $($restResult.Message)"
     }     
 }


### PR DESCRIPTION
PowerShell expandable strings need to use the $(object.property) subexpression syntax or the resulting string will be the full object with the .propertyname text appended to it.

Also added Visual Studio solution and PowerShell project files to allow easier editing of all the scripts as a separate changeset so you can discard that part if you object
